### PR TITLE
Include custom matcher have_all_elements.

### DIFF
--- a/lib/skeleton/features/support/matchers/custom.rb
+++ b/lib/skeleton/features/support/matchers/custom.rb
@@ -12,6 +12,21 @@ RSpec::Matchers.define :all_list_elements_eq do |expected|
   end
 end
 
+## matcher to validate if all elements is contained in
+RSpec::Matchers.define :have_all_elements do |expected|
+  match do |actual|
+    actual.each do |i|
+      expect(expected.include? i).to be true
+    end
+  end
+  failure_message do |actual|
+    "expected that all elements in #{actual} is contained in #{expected}"
+  end
+  description do
+    "have all elements in #{expected}"
+  end
+end
+
 RSpec::Matchers.define :visual_match do |expected|
   match do |actual|
     base_path = File.expand_path(".", Dir.pwd) + '/screenshots/'

--- a/spec/skeleton/support/matchers/custom_test.rb
+++ b/spec/skeleton/support/matchers/custom_test.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../lib/skeleton/features/support/matchers/custom.rb'
+
+RSpec.describe 'custom matchers' do
+    describe "these two arrays [] and []" do
+        it "are empty" do
+            expect([]).to have_all_elements([])
+        end
+    end
+
+    describe [1,2,3] do
+        it {should have_all_elements([2,1,3])}
+
+        it { 
+            expect do
+                should have_all_elements([2,1])
+            end.to raise_error 'expected that all elements in [1, 2, 3] is contained in [2, 1]'
+        }
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
+require 'rspec/expectations'
 SimpleCov.start
 
 RSpec.configure do |config|


### PR DESCRIPTION
Include have_all_elements custom matcher. This matcher ignores sorting.